### PR TITLE
fix unclosed tags hanging

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -63,7 +63,10 @@ Match.prototype._pre = function () {
             next();
         }
     }
-    function end () {}
+    function end () {
+        // forward stream end to avoid hanging on unclosed tags
+        self.emit('end');
+    }
 };
 
 Match.prototype._post = function () {

--- a/test/unclosed_script.js
+++ b/test/unclosed_script.js
@@ -1,0 +1,36 @@
+var select = require('../');
+var test = require('tape');
+var tokenize = require('html-tokenize');
+var through = require('through2');
+var fs = require('fs');
+
+test('unclosed_script', function (t) {
+    t.plan(1);
+    var s = select();
+    s.select('script', function (e) {
+        var s = e.createStream();
+        s.pipe(s);
+    });
+
+
+    var input = [];
+    var output = [];
+
+    fs.createReadStream(__dirname + '/unclosed_script/index.html')
+        .pipe(tokenize())
+        .on('data', function(chunk){
+            input.push(chunk);
+        })
+        .on('end',function(){
+            console.log('end tokenize');
+        })
+        .pipe(s)
+        .on('data', function(chunk){
+            output.push(chunk);
+        })
+        .on('end', function(){
+            t.deepEqual(input,output);
+        });
+
+    s.resume();
+});

--- a/test/unclosed_script/index.html
+++ b/test/unclosed_script/index.html
@@ -1,0 +1,7 @@
+<html>
+    <head>
+    </head>
+    <body>
+        <script>coucou</script>
+    </body>
+


### PR DESCRIPTION
When selecting any tag on an invalid document with unclosed tags, the main stream never `end`s, which is not right IMHO.
Maybe there was a better way to do it, but this seems to work.